### PR TITLE
fix resubscription on complete type

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,6 +53,8 @@ func main() {
 			logger.Stderr.Error("error subscribing to logs", logger.ErrAttr(err))
 			os.Exit(1)
 		}
+
+		logger.Stdout.Debug("log subscription ended")
 	}()
 
 	var (

--- a/railway/data.go
+++ b/railway/data.go
@@ -6,12 +6,20 @@ import (
 	"github.com/hasura/go-graphql-client"
 )
 
+type LogType string
+
+const (
+	TypeNext     LogType = "next"
+	TypeComplete LogType = "complete"
+)
+
 type LogPayloadResponse struct {
 	Payload struct {
 		Data struct {
 			EnvironmentLogs []EnvironmentLog `json:"environmentLogs"`
 		} `json:"data"`
 	} `json:"payload"`
+	Type LogType `json:"type"`
 }
 
 type EnvironmentLog struct {

--- a/railway/subscribe.go
+++ b/railway/subscribe.go
@@ -166,7 +166,6 @@ func (g *GraphQLClient) SubscribeToLogs(logTrack chan<- []EnvironmentLog, trackE
 		_, logPayload, err := safeConnRead(conn, ctx)
 		if err != nil {
 			if errAccumulation > cfg.MaxErrAccumulations {
-				logger.Stdout.Debug("err 1")
 				return err
 			}
 


### PR DESCRIPTION
Previously when Railway was done sending the logs they would simply close the connection and this was accounted for with a seamless resubscription, but recently Railway now sends a "complete" message when they are done sending logs, which has caused locomotive to chug along without sending any new logs out, this PR now takes that into account, and does a seamless resubscription when anything other than "next" is detected.