### PR TITLE
Clean json message attribute of any ansi codes

### DIFF
--- a/railway/subscribe.go
+++ b/railway/subscribe.go
@@ -194,9 +194,8 @@ func (g *GraphQLClient) SubscribeToLogs(ctx context.Context, logTrack chan<- []E
 		filteredLogs := []EnvironmentLog{}
 
 		for i := range logs.Payload.Data.EnvironmentLogs {
-			// skip logs with empty messages
-			if logs.Payload.Data.EnvironmentLogs[i].Message == "" {
-				logger.Stdout.Debug("skipping blank log message")
+			// skip logs with empty messages and no attributes
+			if logs.Payload.Data.EnvironmentLogs[i].Message == "" && len(logs.Payload.Data.EnvironmentLogs[i].Attributes) == 0 {
 				continue
 			}
 

--- a/railway/subscribe.go
+++ b/railway/subscribe.go
@@ -195,7 +195,8 @@ func (g *GraphQLClient) SubscribeToLogs(ctx context.Context, logTrack chan<- []E
 
 		for i := range logs.Payload.Data.EnvironmentLogs {
 			// skip logs with empty messages and no attributes
-			if logs.Payload.Data.EnvironmentLogs[i].Message == "" && len(logs.Payload.Data.EnvironmentLogs[i].Attributes) == 0 {
+			// we check for 1 attribute because empty logs will always have at least one attribute, the level
+			if logs.Payload.Data.EnvironmentLogs[i].Message == "" && len(logs.Payload.Data.EnvironmentLogs[i].Attributes) == 1 {
 				continue
 			}
 


### PR DESCRIPTION
- Cleans the message attribute of any ANSI codes, ANSI Codes can in some cases cause JSON parse errors top be returned from the ingest server.
- Only skip log event if the message and attributes are empty.