### PR TITLE
Docs: add `/loki/api/v1/push` path to `LOKI_INGEST_URL` example URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ All variables:
 
 -   `LOKI_INGEST_URL` - The Loki ingest URL to send logs to.
 
-    -   Example with no authentication: `https://loki-instance.up.railway.app`
-    -   Example with username/password authentication: `https://user:pass@loki-instance.up.railway.app`
+    -   Example with no authentication: `https://loki-instance.up.railway.app/loki/api/v1/push`
+    -   Example with username/password authentication: `https://user:pass@loki-instance.up.railway.app/loki/api/v1/push`
     -   Optional.
 
 -   `INGEST_URL` - The URL to send a generic request to.


### PR DESCRIPTION
## Summary of changes 

This is a pretty minimal change and intends to improve the experience of using locomotive to integrate with Loki. While there are no functional changes required, All this change introduces is the `/loki/api/v1/push` path to the example URLs in the `LOKI_INGEST_URL` option. 

This change should make it clear that, when using loki, you're expected to include the api path to push logs, not just the root domain of your Loki instance. 

## Related issues 

See #18 for context on this change. 